### PR TITLE
Allow links to contain ID fragments.

### DIFF
--- a/assets/js/jquery.slinky.js
+++ b/assets/js/jquery.slinky.js
@@ -77,7 +77,7 @@
 
 			var a = $(this);
 
-			if (/#/.test(this.href) || a.hasClass('next')) {
+			if (/\B#/.test(this.href) || a.hasClass('next')) {
 				e.preventDefault();
 			}
 


### PR DESCRIPTION
Currently, the on click function contains a conditional checking if the href contains a `#` and blocks that with `e.preventDefault()`. This is problematic for people wishing to use the menu to link to anchors with a name or id fragment, for example: `<a href="examplepage.html#contrivedfragment">YAS KWEEN</a>`

Adjusting the regex just a touch unblocks this to allow for name or id fragments while still blocking links with **only** a `#`.